### PR TITLE
Make htmlproofer pretend to be Chrome

### DIFF
--- a/publishing-scripts/publish.sh
+++ b/publishing-scripts/publish.sh
@@ -19,6 +19,8 @@ MOJ_GITHUB=/https...github.com.ministryofjustice.*/
 
 CONFIG_FILE=config/tech-docs.yml
 
+CHROME_USER_AGENT="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.150 Safari/537.36"
+
 main() {
   # Restore the stashed config.rb Gemfile and Gemfile.lock
   cp /stashed-files/* .
@@ -47,6 +49,7 @@ check_for_broken_links() {
     --allow-hash-href \
     --url-ignore "${MOJ_GITHUB},$(site_root)" \
     --url-swap "$(url_swap):" \
+    --typhoeus-config "{\"headers\":{\"User-Agent\":\"${CHROME_USER_AGENT}\"}}" \
     ./docs
 }
 


### PR DESCRIPTION
Some sites (e.g. https://twitter.com) return an
error if the requester does not supply an approved
user-agent header. e.g.

```
curl -I https://twitter.com/alicebartlett
```

...gets a 400 response, but;

```
curl -I -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.150 Safari/537.36" https://twitter.com/alicebartlett
```

...gets a 200 response.

This change makes htmlproofer use the user-agent
above whenever it checks a link.

In testing, this allowed links to twitter profiles
which fail without this change.

> Please create a new release of this project, after merging this PR