### PR TITLE
Ignore 403 and 0 errors

### DIFF
--- a/publishing-scripts/publish.sh
+++ b/publishing-scripts/publish.sh
@@ -45,7 +45,7 @@ compile_html() {
 
 check_for_broken_links() {
   bundle exec htmlproofer \
-    --http-status-ignore 429 \
+    --http-status-ignore 0,429,403 \
     --allow-hash-href \
     --url-ignore "${MOJ_GITHUB},$(site_root)" \
     --url-swap "$(url_swap):" \


### PR DESCRIPTION
Some external links return 0 and 403 even if the page is working correctly. 
This maybe due to the website expecting cookies when requesting