### PR TITLE
✨ Add input for `release_tag` on push to DockerHub

### DIFF
--- a/.github/workflows/cicd-push-docker-image.yml
+++ b/.github/workflows/cicd-push-docker-image.yml
@@ -2,8 +2,11 @@ name: ♻️ Push Docker Image
 
 on:
   workflow_dispatch:
-  release:
-    types: [published]
+    inputs:
+      release_tag:
+        type: string
+        description: Release tag for docker image. In format `v{x}.{y}.{z}` i.e `v3.0.1`
+        required: true
 
 jobs:
   push_to_registry:
@@ -26,7 +29,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
-          tags: ministryofjustice/tech-docs-github-pages-publisher:latest
+          tags: ministryofjustice/tech-docs-github-pages-publisher:{{ inputs.release_tag }}
 
       - name: Report failure to Slack
         if: always()


### PR DESCRIPTION
## 👀 Purpose

- In relation to https://github.com/ministryofjustice/operations-engineering/issues/4081
- To allow the tagging of newer Docker Image versions published to DockerHub

## ♻️ What's changed

- Added `release_tag` input for the Docker Publish workflow, to enable developers to publish a new Docker Image to DockerHub with an updated tag version
- Removed automated trigger from Docker Publish workflow 

## 📝 Notes

- The current deployment process only publishes the `latest` tag - most projects will prefer to fix to a version and so we need a process to tag the docker images published appropriately.
- The release of a GitHub Tag and Tagging a Docker Image are independent processes. To achieve the automated connection between the two would require more thought and work.