### PR TITLE
feat: 🎸 allow `check_interal_hash` to be overridden

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The scripts in the Docker container have changed.
 If you see an error like this:
 
 ```bash
-  internally linking to ./blah-communications-plan.html#tips-on-format-of-communications-examples; the file exists, but the hash 'tips-on-format-of-communications-examples' does not
+  internally linking to ./*-communications-plan.html#tips-on-format-of-communications-examples; the file exists, but the hash 'tips-on-format-of-communications-examples' does not
 ```
 
 You can override the `check_interal_hash` argument with `scripts/deploy.sh false`

--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ The scripts in the Docker container have changed.
 
 `scripts/deploy.sh` is now used to check internal links only during the deploy stage. See `.github/workflows/publish-gh-pages.yml` below.
 
+If you see an error like this:
+
+```bash
+  internally linking to ./blah-communications-plan.html#tips-on-format-of-communications-examples; the file exists, but the hash 'tips-on-format-of-communications-examples' does not
+```
+
+You can override the `check_interal_hash` argument with `scripts/deploy.sh false`
+
+
 [Optional]: Use the `scripts/check-url-links.sh` to test internal and external URLs, it may produce false errors for valid working URLs. Add the `.github/workflows/check-links.yml` below to run the check when the PR is created. The false errors can be ignored.
 
 [Optional]: Use the `url-check` job within `.github/workflows/publish-gh-pages.yml` to check the URLs are correct post deployment. Private and internal Github repository URLs and other URLs that create false errors can be listed and skipped within this job.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3,6 +3,8 @@
 set -x
 set -euo pipefail
 
+CHECK_INTERNAL_HASH=${1:-true}
+
 # Restore the stashed config.rb Gemfile and Gemfile.lock
 cp /stashed-files/* .
 
@@ -12,6 +14,6 @@ bundle exec middleman build --build-dir docs --relative-links --verbose
 touch docs/.nojekyll
 
 # Internal link check only within the docs folder
-htmlproofer --log-level debug --allow-missing-href true --disable_external true ./docs
+htmlproofer --log-level debug --allow-missing-href true --disable_external true --check-internal-hash "$CHECK_INTERNAL_HASH"  ./docs
 
 tar --dereference --directory docs -cvf artifact.tar --exclude=.git --exclude=.github .


### PR DESCRIPTION
We are seeing a lot of the following errors:

```
 internally linking to ./cloud-platform-communications-plan.html#tips-on-format-of-communications-examples; the file exists, but the hash 'tips-on-format-of-communications-examples' does not


HTML-Proofer found 1130 failures!
Error: Process completed with exit code 1.
```

https://github.com/ministryofjustice/cloud-platform/actions/runs/7641643846/job/20819400361

This is preventing us from publishing our docs because htmlproofer is requiring internal hashes exist.

https://github.com/gjtorikian/html-proofer/issues/739