### PR TITLE
🔥 Remove GHCR from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ This repository publishes a utility container for previewing and packaging [GOV.
 
 ### v4
 
-The container is now hosted on GitHub Container Registry.
-
 The scripts have moved:
 
 - `/scripts/deploy.sh` is now `/usr/local/bin/package`


### PR DESCRIPTION
This pull request:

- Removes reference to GHCR in README

This one slipped through @jasonBirchall 

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 