### PR TITLE
🆙 Update `softprops/actions-gh-release` to `v2.0.8`

### DIFF
--- a/.github/workflows/cicd-release.yml
+++ b/.github/workflows/cicd-release.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         
       - name: Release
-        uses: softprops/action-gh-release@970e29c7f0335519b5e1f634dd4d92fdef9bd3ce # v0.1.15
+        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8
         with:
           generate_release_notes: true
           


### PR DESCRIPTION
## 👀 Purpose

- To upgrade dependecies to the latest version
- The commit hash previously didn't align with a version number, meaning dependabot is trying to bump to the latest commit rather than the latest version

## ♻️ What's changed

- Bumped action to latest version

## 📝 Notes

- The bump to [v2](https://github.com/softprops/action-gh-release/releases/tag/v2.0.0) bumps the node version to v20