### PR TITLE
💎 Update `govuk_tech_docs` to 4.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable no-duplicate-heading -->
 # CHANGELOG
 
 Starting from v5.0.0, all notable changes to this project will be documented in this file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v5.0.1] - 2024-11-18
+
+### Changed
+
+- `docker.io/ruby` to `sha256:b4c321a99b9f21b7bb24f22e558bf1477630fb55d692aba4e25b2fe5deb7eaf1`
+
+- `bundler` to `2.5.23`
+
+- `govuk_tech_docs` to `4.4.1` ([CHANGELOG](https://github.com/alphagov/tech-docs-gem/blob/main/CHANGELOG.md#411))
+
+### Removes
+
+- `rexml` `3.3.6` ([CVE-2024-49761](https://github.com/advisories/GHSA-2rxp-v6pw-ch6m))
+
 ## [v5.0.0] - 2024-10-26
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 <!-- markdownlint-disable no-duplicate-heading -->
+
 # CHANGELOG
 
 Starting from v5.0.0, all notable changes to this project will be documented in this file.

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,9 @@ apk --update-cache --no-cache add \
 gem install bundler --version "${BUNDLER_VERSION}"
 
 bundle install
+
+# Removes rexml 3.3.6 to address CVE-2024-49761
+gem uninstall rexml --version 3.3.6 --install-dir /usr/local/lib/ruby/gems/3.3.0 --force
 EOF
 
 WORKDIR /tech-docs-github-pages-publisher

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 #checkov:skip=CKV_DOCKER_2: HEALTHCHECK not required - Image does not run a web server
 #checkov:skip=CKV_DOCKER_3: USER not required        - Image does not run in production, it is a utility
 
-FROM docker.io/ruby@sha256:0bf4169697f44df52cea27b0ceb1a3b715b168625b7c404202e2dfe31dee25e2
+FROM docker.io/ruby@sha256:b4c321a99b9f21b7bb24f22e558bf1477630fb55d692aba4e25b2fe5deb7eaf1
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Operations Engineering (operations-engineering@digital.justice.gov.uk)" \
       org.opencontainers.image.title="Tech Docs GitHub Pages Publisher" \
       org.opencontainers.image.url="https://github.com/ministryofjustice/tech-docs-github-pages-publisher"
 
-ARG BUNDLER_VERSION="2.5.22"
+ARG BUNDLER_VERSION="2.5.23"
 
 SHELL ["/bin/sh", "-e", "-u", "-o", "pipefail", "-c"]
 

--- a/src/opt/publisher/Gemfile
+++ b/src/opt/publisher/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem 'govuk_tech_docs', '4.1.0'
+gem 'govuk_tech_docs', '4.1.1'

--- a/src/opt/publisher/Gemfile.lock
+++ b/src/opt/publisher/Gemfile.lock
@@ -69,7 +69,7 @@ GEM
     google-protobuf (4.28.3-x86_64-linux)
       bigdecimal
       rake (>= 13)
-    govuk_tech_docs (4.1.0)
+    govuk_tech_docs (4.1.1)
       autoprefixer-rails (~> 10.2)
       base64
       bigdecimal
@@ -99,8 +99,8 @@ GEM
     http_parser.rb (0.8.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
-    kramdown (2.4.0)
-      rexml
+    kramdown (2.5.0)
+      rexml (>= 3.3.6)
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -195,19 +195,19 @@ GEM
     rexml (3.3.9)
     rouge (3.30.0)
     sass (3.4.25)
-    sass-embedded (1.80.4-aarch64-linux-gnu)
+    sass-embedded (1.81.0-aarch64-linux-gnu)
       google-protobuf (~> 4.28)
-    sass-embedded (1.80.4-arm-linux-gnueabihf)
+    sass-embedded (1.81.0-arm-linux-gnueabihf)
       google-protobuf (~> 4.28)
-    sass-embedded (1.80.4-arm64-darwin)
+    sass-embedded (1.81.0-arm64-darwin)
       google-protobuf (~> 4.28)
-    sass-embedded (1.80.4-x86-linux-gnu)
+    sass-embedded (1.81.0-x86-linux-gnu)
       google-protobuf (~> 4.28)
-    sass-embedded (1.80.4-x86_64-darwin)
+    sass-embedded (1.81.0-x86_64-darwin)
       google-protobuf (~> 4.28)
-    sass-embedded (1.80.4-x86_64-linux-gnu)
+    sass-embedded (1.81.0-x86_64-linux-gnu)
       google-protobuf (~> 4.28)
-    sass-embedded (1.80.4-x86_64-linux-musl)
+    sass-embedded (1.81.0-x86_64-linux-musl)
       google-protobuf (~> 4.28)
     sassc (2.4.0)
       ffi (~> 1.9)
@@ -228,7 +228,7 @@ GEM
       concurrent-ruby (~> 1.0)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
-    webrick (1.8.2)
+    webrick (1.9.0)
 
 PLATFORMS
   aarch64-linux
@@ -240,7 +240,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  govuk_tech_docs (= 4.1.0)
+  govuk_tech_docs (= 4.1.1)
 
 BUNDLED WITH
-   2.5.22
+   2.5.23


### PR DESCRIPTION
This pull request:

- Updates container image to latest SHA for `docker.io/ruby:3.3.5-alpine3.20`
- Updates Bundler to 2.5.23
- Updates `govuk_tech_docs` to 4.4.1
- Uninstalls rexml 3.3.6 from one of the Gem paths (`/usr/local/lib/ruby/gems/3.3.0`) to address CVE-2024-49761

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 