### PR TITLE
📌 Update to 5.0.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
       interval: "daily"
       time: "09:00" # UTC
   - package-ecosystem: "bundler"
-    directory: "/"
+    directory: "src/opt/publisher"
     schedule:
       interval: "daily"
       time: "09:00" # UTC

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #checkov:skip=CKV_DOCKER_2: HEALTHCHECK not required - Image does not run a web server
 #checkov:skip=CKV_DOCKER_3: USER not required        - Image does not run in production, it is a utility
 
-FROM docker.io/ruby:3.3.8-alpine3.22@sha256:73ee3f4ab883b972df42ff9e393627bd4c09befd3a4ee7ce08ca9bfd62791b0c
+FROM docker.io/ruby:3.3.8-alpine3.22@sha256:e96d7c0f29e2fc89de8a6566865defcce3fdaf682f949bc84f5a5c944bbc2ad6
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="GitHub Community (github-community@digital.justice.gov.uk)" \
@@ -19,7 +19,7 @@ WORKDIR /opt/publisher
 RUN <<EOF
 apk --update-cache --no-cache add \
   build-base==0.5-r3 \
-  git==2.49.0-r0 \
+  git==2.49.1-r0 \
   nodejs==22.16.0-r2
 
 gem install bundler --version "${BUNDLER_VERSION}"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test package preview scan
+.PHONY: build test package preview scan copy-gemlock exec
 
 IMAGE_NAME ?= ghcr.io/ministryofjustice/tech-docs-github-pages-publisher
 IMAGE_TAG  ?= local
@@ -42,3 +42,8 @@ preview: build
 
 scan: build
 	trivy image --platform linux/amd64 --severity HIGH,CRITICAL $(IMAGE_NAME):$(IMAGE_TAG)
+
+copy-gemlock: build
+	docker create --name tech-docs-github-pages-publisher-tmp $(IMAGE_NAME):$(IMAGE_TAG)
+	docker container cp tech-docs-github-pages-publisher-tmp://opt/publisher/Gemfile.lock src/opt/publisher/Gemfile.lock
+	docker rm tech-docs-github-pages-publisher-tmp

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ docker image inspect --format='{{ index .RepoDigests 0 }}' docker.io/ruby:3.3.8-
 > [!IMPORTANT]
 > Dependabot is configured to maintain these, however this repository is just packaging `govuk_tech_docs`, so proceed with caution when reviewing and approving
 
-When the Government Digital Service release a new version of [`govuk_tech_docs`](https://rubygems.org/gems/govuk_tech_docs), update [`src/opt/publisher/Gemfile`](src/opt/publisher/Gemfile) and run `make build` to generate a new `Gemfile.lock`, then run `make exec` and take a copy of `/opt/publisher/Gemfile.lock` to overwrite [`src/opt/publisher/Gemfile.lock`](src/opt/publisher/Gemfile.lock).
+When the Government Digital Service release a new version of [`govuk_tech_docs`](https://rubygems.org/gems/govuk_tech_docs), update [`src/opt/publisher/Gemfile`](src/opt/publisher/Gemfile) and run `make copy-gemlock`. This will build the image, and copy the generated `Gemfile.lock` out of the image.
 
 ## Releasing
 

--- a/src/opt/publisher/Gemfile
+++ b/src/opt/publisher/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem 'govuk_tech_docs', '5.0.0'
+gem 'govuk_tech_docs', '5.0.2'

--- a/src/opt/publisher/Gemfile.lock
+++ b/src/opt/publisher/Gemfile.lock
@@ -69,7 +69,7 @@ GEM
     google-protobuf (4.28.3-x86_64-linux)
       bigdecimal
       rake (>= 13)
-    govuk_tech_docs (5.0.0)
+    govuk_tech_docs (5.0.2)
       autoprefixer-rails (~> 10.2)
       base64
       bigdecimal
@@ -245,7 +245,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  govuk_tech_docs (= 5.0.0)
+  govuk_tech_docs (= 5.0.2)
 
 BUNDLED WITH
    2.6.9


### PR DESCRIPTION
## Proposed Changes

- Updates [`alphagov/tech-docs-gem` ](https://github.com/alphagov/tech-docs-gem) to [`v5.0.2`](https://github.com/alphagov/tech-docs-gem/releases/tag/v5.0.2)
  - Diff [`v5.0.0...v5.0.2`](https://github.com/alphagov/tech-docs-gem/compare/v5.0.0...v5.0.2)
- Updates Dependabot's `bundler` directory
- Updates Alpine's SHA and packages
- Adds `copy-gemlock` Make instruction to replace manual steps of extracting `Gemfile.lock`

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>