### PR TITLE
chore: bump analytical-platform-github-actions to v7.1.0

### DIFF
--- a/.github/workflows/cicd-container-scan.yml
+++ b/.github/workflows/cicd-container-scan.yml
@@ -13,4 +13,4 @@ jobs:
     name: Container Scan
     permissions:
       contents: read
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-scan.yml@72a6b41dd6f2ccce15aa70b0e42178f6f5583018 # v5.3.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-scan.yml@8465086d84a8ae8fb993ef582f00cf13b8ceb9c8 # v7.1.0


### PR DESCRIPTION
Updates the following to pinned commit 8465086d84a8ae8fb993ef582f00cf13b8ceb9c8 (v7.1.0):

- ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-scheduled-container-scan.yml
- ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-scan.yml