### PR TITLE
🛡️ Add missing permission for CodeQL

### DIFF
--- a/.github/workflows/cicd-codeql-analysis.yml
+++ b/.github/workflows/cicd-codeql-analysis.yml
@@ -15,6 +15,7 @@ jobs:
   codeql-analysis:
     name: CodeQL Analysis
     permissions:
+      actions: read
       contents: read
       security-events: write
     uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-codeql-analysis.yml@7c80b25e08b491427f45316a8c10ba44232d985f # v7.2.0


### PR DESCRIPTION
This pull request makes a minor update to the CodeQL Analysis workflow by adding the `actions: read` permission to the workflow's permissions block.

* [`.github/workflows/cicd-codeql-analysis.yml`](diffhunk://#diff-8e6b7e86b4b2ed1141ea0e1fce8f9de632dfedb34ba6e189092ceaec564f7ca9R18): Added `actions: read` permission to the CodeQL Analysis workflow permissions.

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>